### PR TITLE
Subscribe on PreDispatch_Frontend event, so VariantFilter will not apply in backend

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -25,7 +25,7 @@ class Shopware_Plugins_Frontend_SwagVariantFilter_Bootstrap extends Shopware_Com
     {
         $this->createForm();
         $this->createTranslations();
-        $this->subscribeEvent('Enlight_Controller_Front_DispatchLoopStartup', 'onStartDispatch');
+        $this->subscribeEvent('Enlight_Controller_Action_PreDispatch_Frontend', 'onStartDispatch');
 
         return true;
     }
@@ -99,6 +99,8 @@ class Shopware_Plugins_Frontend_SwagVariantFilter_Bootstrap extends Shopware_Com
      */
     public function update($version)
     {
+        $this->subscribeEvent('Enlight_Controller_Action_PreDispatch_Frontend', 'onStartDispatch');
+
         return true;
     }
 


### PR DESCRIPTION
Should fix the issue with variant filters in combination with product streams. We talked about this fix some while ago, @MarcelSchmaeing 

see http://forum.shopware.com/allgemein-f98/problem-mit-gefiltertem-product-stream-t34293.html#p149401
